### PR TITLE
Prevent DOM rebuilds during audio playback

### DIFF
--- a/static/js/events.js
+++ b/static/js/events.js
@@ -10,6 +10,15 @@ const Events = (() => {
     let total = 0;
     let pollTimer = null;
 
+    /** Returns true if any <audio> element on the page is currently playing. */
+    function isAudioPlaying() {
+        const players = document.querySelectorAll('audio');
+        for (const a of players) {
+            if (!a.paused && !a.ended) return true;
+        }
+        return false;
+    }
+
     function init() {
         setupFilters();
         loadEvents(true);
@@ -39,6 +48,9 @@ const Events = (() => {
 
     async function loadEvents(replace) {
         try {
+            // Skip DOM rebuild while audio is playing to avoid killing playback
+            if (replace && isAudioPlaying()) return;
+
             let url = `/api/events?limit=${LIMIT}&offset=${replace ? 0 : offset}`;
             if (currentFilter) url += `&type=${currentFilter}`;
 
@@ -74,6 +86,9 @@ const Events = (() => {
 
     async function loadActiveEvents() {
         try {
+            // Skip DOM rebuild while audio is playing to avoid killing playback
+            if (isAudioPlaying()) return;
+
             const resp = await fetch('/api/events/active');
             if (!resp.ok) return;
             const data = await resp.json();


### PR DESCRIPTION
## Summary
This PR adds a check to prevent DOM rebuilds while audio elements are actively playing on the page. This ensures that audio playback is not interrupted when events are refreshed or reloaded.

## Changes
- Added `isAudioPlaying()` helper function that checks if any `<audio>` element on the page is currently playing
- Modified `loadEvents()` to skip DOM rebuild when audio is playing and a full replace is requested
- Modified `loadActiveEvents()` to skip DOM rebuild when audio is playing

## Implementation Details
The `isAudioPlaying()` function iterates through all audio elements and returns `true` if any element is neither paused nor ended. This check is performed before fetching and rebuilding the DOM to avoid interrupting active audio playback.

The guards are strategically placed:
- In `loadEvents()`: Only skips when `replace` is true (full rebuild), allowing incremental updates to proceed
- In `loadActiveEvents()`: Always skips if audio is playing, as this function also rebuilds the DOM

https://claude.ai/code/session_011mGV2jWV8jVmsPTRAizvDR