### PR TITLE
Remove EON traffic events from UI and database

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -195,9 +195,6 @@ main {
 .event-card.type-emergency .event-type { color: var(--accent-orange); }
 .event-card.type-emergency { border-left: 3px solid var(--accent-orange); }
 
-.event-card.type-eon_traffic .event-indicator { background: var(--accent-blue); }
-.event-card.type-eon_traffic .event-type { color: var(--accent-blue); }
-
 .event-time {
     font-size: 0.8125rem;
     color: var(--text-muted);

--- a/static/index.html
+++ b/static/index.html
@@ -26,7 +26,6 @@
                 <button class="filter-chip active" data-type="">All</button>
                 <button class="filter-chip" data-type="traffic">Traffic</button>
                 <button class="filter-chip" data-type="emergency">Emergency</button>
-                <button class="filter-chip" data-type="eon_traffic">EON</button>
             </div>
             <div id="active-events"></div>
             <div id="events-list"></div>

--- a/static/js/events.js
+++ b/static/js/events.js
@@ -133,7 +133,6 @@ const Events = (() => {
         const typeLabels = {
             traffic: 'Traffic Announcement',
             emergency: 'Emergency Broadcast',
-            eon_traffic: 'EON Traffic',
         };
 
         const timeStr = formatTime(ev.started_at || ev.created_at);
@@ -167,23 +166,6 @@ const Events = (() => {
                 html += `<p>${escapeHtml(rt)}</p>`;
             });
             html += '</div>';
-        }
-
-        // EON linked station
-        if (ev.type === 'eon_traffic') {
-            let data = ev.data;
-            if (typeof data === 'string') {
-                try { data = JSON.parse(data); } catch (e) { data = null; }
-            }
-            if (data && data.linked_station) {
-                const ls = data.linked_station;
-                const lsParts = [];
-                if (ls.ps) lsParts.push(ls.ps);
-                if (ls.pi) lsParts.push(ls.pi);
-                if (lsParts.length) {
-                    html += `<div class="event-station">Linked: ${escapeHtml(lsParts.join(' \u00b7 '))}</div>`;
-                }
-            }
         }
 
         // Transcription


### PR DESCRIPTION
EON TA only indicates a linked station on another frequency has a TA active — no audio, no transcription, no actionable detail for the core purpose of catching traffic/emergency events on the tuned P4 channel.

- Stop inserting eon_traffic events into the database
- Remove EON filter chip from the web UI
- Remove EON linked-station rendering and CSS
- Keep MQTT + WebSocket publishing for Home Assistant consumers

https://claude.ai/code/session_011mGV2jWV8jVmsPTRAizvDR