### PR TITLE
Overhaul console: always-on WebSocket, formatted output, group filters

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -438,12 +438,42 @@ main {
     font-size: 0.8125rem;
     line-height: 1.5;
     overflow-y: auto;
-    height: calc(100vh - 16rem);
+    height: calc(100vh - 19rem);
+}
+
+/* Console group filter chips */
+.console-group-bar {
+    display: flex;
+    gap: 0.375rem;
+    margin-bottom: 0.75rem;
+    flex-wrap: wrap;
+}
+
+.console-group-chip {
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    color: var(--text-secondary);
+    padding: 0.25rem 0.625rem;
+    border-radius: 100px;
+    font-size: 0.75rem;
+    cursor: pointer;
+    transition: all 0.15s;
+}
+
+.console-group-chip:hover {
+    border-color: var(--text-muted);
+    color: var(--text-primary);
+}
+
+.console-group-chip.active {
+    background: var(--accent-blue-dim);
+    border-color: var(--accent-blue);
+    color: var(--accent-blue);
 }
 
 .console-line {
     display: flex;
-    gap: 1rem;
+    gap: 0.75rem;
     padding: 0.125rem 0.5rem;
     border-radius: 3px;
 }
@@ -457,19 +487,49 @@ main {
     flex-shrink: 0;
 }
 
-.console-topic {
+.console-group {
     color: var(--accent-blue);
-    min-width: 10rem;
+    min-width: 7rem;
     flex-shrink: 0;
+    font-weight: 500;
 }
 
-.console-payload {
+.console-detail {
     color: var(--text-secondary);
-    word-break: break-all;
     flex: 1;
+    min-width: 0;
 }
 
-.console-line.is-alert .console-topic {
+/* Console detail formatting */
+.cd-key {
+    color: var(--text-muted);
+    font-weight: 600;
+    font-size: 0.6875rem;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+}
+
+.cd-sep {
+    color: var(--text-muted);
+    margin: 0 0.125rem;
+}
+
+.cd-flag {
+    color: var(--text-muted);
+    font-size: 0.75rem;
+}
+
+.cd-flag.cd-on {
+    color: var(--accent-green);
+    font-weight: 600;
+}
+
+.cd-raw {
+    color: var(--text-muted);
+    font-size: 0.75rem;
+}
+
+.console-line.is-alert .console-group {
     color: var(--accent-red);
     font-weight: 600;
 }

--- a/static/index.html
+++ b/static/index.html
@@ -38,8 +38,17 @@
         <section id="view-console" class="view">
             <div class="console-controls">
                 <button id="console-pause" class="console-btn">Pause</button>
+                <button id="console-clear" class="console-btn">Clear</button>
                 <input id="console-filter" type="text" placeholder="Filter messages..." class="console-input">
                 <span id="console-count" class="console-count">0 messages</span>
+            </div>
+            <div class="console-group-bar">
+                <button class="console-group-chip active" data-group="">All</button>
+                <button class="console-group-chip" data-group="0a">PS/Flags</button>
+                <button class="console-group-chip" data-group="2a">RadioText</button>
+                <button class="console-group-chip" data-group="4a">Clock</button>
+                <button class="console-group-chip" data-group="14a">EON</button>
+                <button class="console-group-chip" data-group="alert">Alerts</button>
             </div>
             <div id="console-log" class="console-log"></div>
         </section>

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -29,13 +29,6 @@ const App = (() => {
 
         document.querySelectorAll('.view').forEach(v => v.classList.remove('active'));
         document.getElementById(`view-${view}`).classList.add('active');
-
-        // Connect/disconnect WebSocket based on view
-        if (view === 'console') {
-            Console.connect();
-        } else {
-            Console.disconnect();
-        }
     }
 
     async function pollStatus() {
@@ -169,4 +162,5 @@ document.addEventListener('DOMContentLoaded', () => {
     App.init();
     Events.init();
     Console.init();
+    Console.connect();
 });

--- a/static/js/console.js
+++ b/static/js/console.js
@@ -7,15 +7,46 @@ const Console = (() => {
     let ws = null;
     let paused = false;
     let filterText = '';
+    let groupFilter = '';
     let messages = [];
     const MAX_MESSAGES = 500;
     let reconnectTimer = null;
 
+    /** Human-readable labels for RDS group types. */
+    const GROUP_LABELS = {
+        '0a': 'PS / Flags',
+        '0b': 'PS / Flags',
+        '1a': 'PIN / Slow',
+        '1b': 'PIN',
+        '2a': 'RadioText',
+        '2b': 'RadioText',
+        '3a': 'ODA',
+        '4a': 'Clock',
+        '10a': 'PTYN',
+        '11a': 'RT+',
+        '14a': 'EON',
+        'alert': 'Alert',
+        'transcription': 'Transcription',
+    };
+
     function init() {
         document.getElementById('console-pause').addEventListener('click', togglePause);
+        document.getElementById('console-clear').addEventListener('click', clearLog);
         document.getElementById('console-filter').addEventListener('input', (e) => {
             filterText = e.target.value.toLowerCase();
             renderAll();
+        });
+        setupGroupFilters();
+    }
+
+    function setupGroupFilters() {
+        document.querySelectorAll('.console-group-chip').forEach(chip => {
+            chip.addEventListener('click', () => {
+                document.querySelectorAll('.console-group-chip').forEach(c => c.classList.remove('active'));
+                chip.classList.add('active');
+                groupFilter = chip.dataset.group;
+                renderAll();
+            });
         });
     }
 
@@ -70,11 +101,7 @@ const Console = (() => {
 
     function scheduleReconnect() {
         clearReconnectTimer();
-        // Only reconnect if console view is active
-        const consoleView = document.getElementById('view-console');
-        if (consoleView && consoleView.classList.contains('active')) {
-            reconnectTimer = setTimeout(() => connect(), 3000);
-        }
+        reconnectTimer = setTimeout(() => connect(), 3000);
     }
 
     function clearReconnectTimer() {
@@ -95,6 +122,12 @@ const Console = (() => {
             btn.classList.remove('paused');
             renderAll();
         }
+    }
+
+    function clearLog() {
+        messages = [];
+        document.getElementById('console-log').innerHTML = '';
+        updateCount();
     }
 
     function appendLine(msg) {
@@ -131,35 +164,124 @@ const Console = (() => {
         div.className = 'console-line';
 
         const topic = msg.topic || '';
-        if (topic === 'alert' || topic.includes('alert')) {
-            div.classList.add('is-alert');
-        }
+        const isAlert = topic === 'alert' || topic.includes('alert');
+        if (isAlert) div.classList.add('is-alert');
 
         const ts = formatTs(msg.timestamp);
-        const shortTopic = topic.replace(/^0x[0-9A-Fa-f]+\//, '');
-        const payload = typeof msg.payload === 'string'
-            ? msg.payload
-            : JSON.stringify(msg.payload);
+        const group = extractGroup(topic);
+        const groupLabel = GROUP_LABELS[group] || group.toUpperCase();
+        const detail = formatPayload(group, msg.payload, isAlert);
 
         div.innerHTML = `
             <span class="console-ts">${escapeHtml(ts)}</span>
-            <span class="console-topic">${escapeHtml(shortTopic)}</span>
-            <span class="console-payload">${escapeHtml(truncate(payload, 300))}</span>
+            <span class="console-group">${escapeHtml(groupLabel)}</span>
+            <span class="console-detail">${detail}</span>
         `;
         return div;
     }
 
+    /** Extract the RDS group from a topic like "0xE824/2a" → "2a". */
+    function extractGroup(topic) {
+        if (!topic) return 'unknown';
+        if (topic === 'alert' || topic.startsWith('alert')) return 'alert';
+        if (topic === 'transcription') return 'transcription';
+        const parts = topic.split('/');
+        return parts.length > 1 ? parts[parts.length - 1].toLowerCase() : topic.toLowerCase();
+    }
+
+    /** Format payload into human-readable detail based on group type. */
+    function formatPayload(group, payload, isAlert) {
+        if (!payload) return '';
+        const p = typeof payload === 'object' ? payload : {};
+
+        if (isAlert) {
+            const parts = [];
+            if (p.type) parts.push(`<span class="cd-key">${escapeHtml(p.type)}</span>`);
+            if (p.state) parts.push(escapeHtml(p.state));
+            if (p.station && p.station.ps) parts.push(escapeHtml(p.station.ps));
+            if (p.transcription) parts.push('"' + escapeHtml(truncate(p.transcription, 80)) + '"');
+            return parts.join(' <span class="cd-sep">&middot;</span> ') || raw(payload);
+        }
+
+        switch (group) {
+            case '0a':
+            case '0b': {
+                const parts = [];
+                if (p.ps) parts.push(`<span class="cd-key">PS</span> ${escapeHtml(p.ps)}`);
+                else if (p.partial_ps) parts.push(`<span class="cd-key">PS</span> ${escapeHtml(p.partial_ps)}`);
+                if (p.ta != null) parts.push(flag('TA', p.ta));
+                if (p.tp != null) parts.push(flag('TP', p.tp));
+                if (p.prog_type) parts.push(`<span class="cd-key">PTY</span> ${escapeHtml(p.prog_type)}`);
+                if (p.is_music != null) parts.push(p.is_music ? 'Music' : 'Speech');
+                return parts.join(' <span class="cd-sep">&middot;</span> ') || raw(payload);
+            }
+            case '2a':
+            case '2b': {
+                const rt = p.radiotext || p.partial_radiotext;
+                if (rt) return `<span class="cd-key">RT</span> ${escapeHtml(rt)}`;
+                return raw(payload);
+            }
+            case '4a': {
+                if (p.clock_time) return `<span class="cd-key">Time</span> ${escapeHtml(p.clock_time)}`;
+                return raw(payload);
+            }
+            case '14a': {
+                const on = p.other_network || {};
+                const parts = [];
+                if (on.ps) parts.push(escapeHtml(on.ps));
+                if (on.pi) parts.push(escapeHtml(on.pi));
+                if (on.ta != null) parts.push(flag('TA', on.ta));
+                if (parts.length) return `<span class="cd-key">EON</span> ${parts.join(' <span class="cd-sep">&middot;</span> ')}`;
+                return raw(payload);
+            }
+            case '1a':
+            case '1b': {
+                const parts = [];
+                if (p.pin) parts.push(`<span class="cd-key">PIN</span> ${escapeHtml(String(p.pin))}`);
+                if (p.ecc) parts.push(`ECC: ${escapeHtml(String(p.ecc))}`);
+                return parts.join(' <span class="cd-sep">&middot;</span> ') || raw(payload);
+            }
+            case '10a': {
+                if (p.ptyn) return `<span class="cd-key">PTYN</span> ${escapeHtml(p.ptyn)}`;
+                return raw(payload);
+            }
+            case 'transcription': {
+                const parts = [];
+                if (p.event_id) parts.push(`Event #${p.event_id}`);
+                if (p.transcription) parts.push('"' + escapeHtml(truncate(p.transcription, 120)) + '"');
+                return parts.join(' <span class="cd-sep">&middot;</span> ') || raw(payload);
+            }
+            default:
+                return raw(payload);
+        }
+    }
+
+    function flag(name, on) {
+        return `<span class="cd-flag ${on ? 'cd-on' : ''}">${name}:${on ? 'ON' : 'off'}</span>`;
+    }
+
+    function raw(payload) {
+        const str = typeof payload === 'string' ? payload : JSON.stringify(payload);
+        return `<span class="cd-raw">${escapeHtml(truncate(str, 200))}</span>`;
+    }
+
     function matchesFilter(msg) {
+        const topic = msg.topic || '';
+        const group = extractGroup(topic);
+
+        // Group chip filter
+        if (groupFilter && group !== groupFilter) return false;
+
+        // Text filter
         if (!filterText) return true;
-        const topic = (msg.topic || '').toLowerCase();
-        const payload = JSON.stringify(msg.payload || '').toLowerCase();
-        return topic.includes(filterText) || payload.includes(filterText);
+        const topicLower = topic.toLowerCase();
+        const payloadStr = JSON.stringify(msg.payload || '').toLowerCase();
+        return topicLower.includes(filterText) || payloadStr.includes(filterText);
     }
 
     function formatTs(iso) {
         if (!iso) return '';
         try {
-            // If it's already just a time, return it
             if (iso.length <= 8) return iso;
             return iso.substring(11, 19);
         } catch (e) {


### PR DESCRIPTION
The console was empty because the WebSocket only connected when the Console tab was active and disconnected when switching away.

Changes:
- Connect WebSocket on page load and always reconnect on close, so messages accumulate in the background regardless of active tab
- Format RDS groups into human-readable output (PS/Flags show station name + TA/TP flags, RadioText shows RT content, EON shows linked station info, etc.) instead of raw JSON
- Add group filter chips (All, PS/Flags, RadioText, Clock, EON, Alerts) for quick filtering by RDS group type
- Add Clear button to reset the message buffer
- Text filter and group filter work together (intersection)

https://claude.ai/code/session_011mGV2jWV8jVmsPTRAizvDR