### PR TITLE
Fix console init crash when HTML is cached without clear button

### DIFF
--- a/static/js/console.js
+++ b/static/js/console.js
@@ -31,7 +31,8 @@ const Console = (() => {
 
     function init() {
         document.getElementById('console-pause').addEventListener('click', togglePause);
-        document.getElementById('console-clear').addEventListener('click', clearLog);
+        const clearBtn = document.getElementById('console-clear');
+        if (clearBtn) clearBtn.addEventListener('click', clearLog);
         document.getElementById('console-filter').addEventListener('input', (e) => {
             filterText = e.target.value.toLowerCase();
             renderAll();


### PR DESCRIPTION
If the browser serves cached old HTML (missing #console-clear) with the new JS, getElementById returns null and addEventListener throws, crashing init() and preventing the WebSocket from connecting.

https://claude.ai/code/session_011mGV2jWV8jVmsPTRAizvDR