### PR TITLE
Fix empty console: resolve __main__ vs rds_guard dual-module bug

### DIFF
--- a/rds_guard.py
+++ b/rds_guard.py
@@ -1300,4 +1300,11 @@ def main():
 
 
 if __name__ == "__main__":
+    # Register this module under its proper name so that `import rds_guard`
+    # in other modules (e.g. web_server) returns THIS module instance instead
+    # of loading a second copy.  Without this, __main__ and rds_guard would be
+    # two separate objects with independent _ws_clients / _event_loop state.
+    import sys
+    sys.modules["rds_guard"] = sys.modules[__name__]
+
     main()


### PR DESCRIPTION
When run as `python3 rds_guard.py`, the module is loaded as __main__. web_server.py then does `import rds_guard`, creating a SECOND copy. The pipeline calls broadcast_ws() from __main__ (empty _ws_clients), while register_ws() adds clients to the rds_guard copy — so messages never reach the browser.

Fix: register __main__ as sys.modules["rds_guard"] before anything else runs, ensuring a single shared module instance.

https://claude.ai/code/session_011mGV2jWV8jVmsPTRAizvDR