### PR TITLE
Fix raw JSON in console for 1A (PIN) and 10A (PTYN) groups

### DIFF
--- a/static/js/console.js
+++ b/static/js/console.js
@@ -245,12 +245,24 @@ const Console = (() => {
             case '1a':
             case '1b': {
                 const parts = [];
-                if (p.pin) parts.push(`<span class="cd-key">PIN</span> ${escapeHtml(String(p.pin))}`);
-                if (p.ecc) parts.push(`ECC: ${escapeHtml(String(p.ecc))}`);
+                if (p.prog_item_number) {
+                    parts.push(`<span class="cd-key">PIN</span> ${escapeHtml(String(p.prog_item_number))}`);
+                }
+                if (p.prog_item_started) {
+                    const s = p.prog_item_started;
+                    if (s.time) parts.push(`<span class="cd-key">Start</span> ${escapeHtml(s.time)}`);
+                }
+                if (p.country) parts.push(`<span class="cd-key">Country</span> ${escapeHtml(p.country)}`);
+                if (p.language) parts.push(`<span class="cd-key">Lang</span> ${escapeHtml(p.language)}`);
+                if (p.ecc) parts.push(`<span class="cd-key">ECC</span> ${escapeHtml(String(p.ecc))}`);
+                if (p.has_linkage != null) parts.push(flag('Linkage', p.has_linkage));
                 return parts.join(' <span class="cd-sep">&middot;</span> ') || raw(payload);
             }
             case '10a': {
-                if (p.ptyn) return `<span class="cd-key">PTYN</span> ${escapeHtml(p.ptyn)}`;
+                const name = (p.pty_name || p.ptyn || '').trim();
+                if (name) return `<span class="cd-key">PTYN</span> ${escapeHtml(name)}`;
+                // No useful PTYN content — show PTY if available
+                if (p.prog_type) return `<span class="cd-key">PTY</span> ${escapeHtml(p.prog_type)}`;
                 return raw(payload);
             }
             case 'transcription': {


### PR DESCRIPTION
JS formatters:
- 1A: use redsea field names (prog_item_number, prog_item_started, country, language, ews) instead of non-existent pin/ecc
- 10A: use pty_name (redsea) not ptyn; skip whitespace-only values

Server filtering:
- Skip 10A groups with empty/whitespace pty_name
- Deduplicate 1A on core fields (PIN + start time) only, since slow labeling codes (country/language/ews) rotate across groups

https://claude.ai/code/session_011mGV2jWV8jVmsPTRAizvDR