### PR TITLE
Discard short events (<10s) and fix stuck Recording status

### DIFF
--- a/audio_recorder.py
+++ b/audio_recorder.py
@@ -27,7 +27,7 @@ class AudioRecorder:
     CHANNELS = 1            # mono
 
     # Recording limits
-    MIN_DURATION_SEC = 2    # discard very short recordings
+    MIN_DURATION_SEC = 10   # discard recordings shorter than 10s
 
     def __init__(self, audio_dir, transcriber, on_transcription_complete,
                  max_duration_sec=600):

--- a/event_store.py
+++ b/event_store.py
@@ -222,6 +222,18 @@ def update_event_transcription_status(event_id, status):
         conn.commit()
 
 
+def delete_event(event_id):
+    """Delete a single event by ID. Returns True if a row was deleted."""
+    with _lock:
+        conn = _conn()
+        cur = conn.execute("DELETE FROM events WHERE id = ?", (event_id,))
+        conn.commit()
+        deleted = cur.rowcount > 0
+        if deleted:
+            log.info("Deleted event %d", event_id)
+        return deleted
+
+
 def purge_old_events(days):
     """Delete events older than the given number of days.
 

--- a/rds_guard.py
+++ b/rds_guard.py
@@ -350,6 +350,14 @@ class RulesEngine:
                             event_id, "saving")
 
                 duration = self._duration(ann.get("since"), ts)
+
+                # Discard very short events (<10s) — likely RDS noise
+                if duration < 10 and event_id:
+                    event_store.delete_event(event_id)
+                    log.info("Discarded short traffic event #%d on %s "
+                             "(%ds < 10s minimum)", event_id, pi, duration)
+                    return
+
                 payload = {
                     "type": "traffic",
                     "state": "end",
@@ -463,6 +471,14 @@ class RulesEngine:
                     event_id, "saving")
 
         duration = self._duration(em.get("since"), ts)
+
+        # Discard very short events (<10s) — likely RDS noise
+        if duration < 10:
+            event_store.delete_event(event_id)
+            log.info("Discarded short emergency event #%d on %s "
+                     "(%ds < 10s minimum)", event_id, pi, duration)
+            return
+
         event_store.end_event(
             event_id=event_id,
             ended_at=ts,


### PR DESCRIPTION
## Summary
- **Bug fix**: Short TA events (0-1s) got stuck showing "🔴 Recording..." forever because `transcription_status` was set to `"recording"` on TA start but never cleared when the audio recording was discarded as too short
- **Improvement**: Events shorter than 10 seconds are now deleted from the database entirely when they end, since they're RDS noise/glitches rather than real traffic announcements
- **Alignment**: `AudioRecorder.MIN_DURATION_SEC` raised from 2→10 to match the event discard threshold

## Test plan
- [ ] Deploy and verify short TA glitches (<10s) no longer appear in the Events tab
- [ ] Verify real traffic announcements (>10s) still record, transcribe, and display correctly
- [ ] Confirm no "Recording..." labels persist on ended events

🤖 Generated with [Claude Code](https://claude.com/claude-code)