### PR TITLE
Add build version display to footer status bar

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -46,6 +46,15 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=sha
 
+      - name: Determine build version
+        id: version
+        run: |
+          if [[ "${{ github.ref }}" == refs/tags/v* ]]; then
+            echo "value=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
@@ -54,5 +63,6 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: BUILD_VERSION=${{ steps.version.outputs.value }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -67,6 +67,9 @@ COPY static/ /app/static/
 # Data volume for SQLite database
 VOLUME /data
 
+ARG BUILD_VERSION=dev
+ENV BUILD_VERSION=${BUILD_VERSION}
+
 WORKDIR /app
 
 EXPOSE 8022

--- a/config.py
+++ b/config.py
@@ -14,6 +14,9 @@ def _int(val, default):
         return default
 
 
+# Build version (injected at Docker build time, defaults to "dev")
+BUILD_VERSION = os.environ.get("BUILD_VERSION", "dev")
+
 # RTL-SDR
 FM_FREQUENCY = os.environ.get("FM_FREQUENCY", "103.5M")
 RTL_GAIN = os.environ.get("RTL_GAIN", "8")

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -655,6 +655,18 @@ footer {
     50% { opacity: 0.3; }
 }
 
+/* Version link in status bar */
+.status-version {
+    font-size: 0.6875rem;
+    color: var(--text-muted);
+    text-decoration: none;
+    transition: color 0.15s;
+}
+
+.status-version:hover {
+    color: var(--accent-blue);
+}
+
 /* RadioText display in status bar */
 .status-rt-area {
     display: flex;

--- a/static/index.html
+++ b/static/index.html
@@ -73,6 +73,8 @@
                 <span id="status-rate">--- grp/s</span>
                 <span class="status-sep">&middot;</span>
                 <span id="status-uptime" title="Uptime">---</span>
+                <span class="status-sep">&middot;</span>
+                <a id="status-version" class="status-version" href="https://github.com/tubalainen/rds-guard" target="_blank" rel="noopener noreferrer" title="View on GitHub">---</a>
             </div>
         </div>
         <div class="status-row status-row-info">

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -106,6 +106,12 @@ const App = (() => {
         };
         pipeEl.title = pipeLabels[pipeState] || 'Pipeline: ' + pipeState;
 
+        // Version
+        const versionEl = document.getElementById('status-version');
+        if (data.version) {
+            versionEl.textContent = data.version;
+        }
+
         // --- Row 2: RadioText + Now Playing ---
 
         if (station) {

--- a/web_server.py
+++ b/web_server.py
@@ -112,6 +112,7 @@ async def handle_status(request):
     else:
         snap["pipeline"] = {"state": "unknown"}
 
+    snap["version"] = cfg.BUILD_VERSION
     snap["timestamp"] = time.strftime("%Y-%m-%dT%H:%M:%S", time.gmtime())
     return web.json_response(snap)
 


### PR DESCRIPTION
## Summary
- Inject `BUILD_VERSION` as a Docker build-arg from GitHub Actions (git tag for releases, short SHA for branch builds)
- Display version in the footer status bar as a clickable link to the GitHub repo (opens in new tab)
- Served via the existing `/api/status` endpoint, updated on every 5-second poll

## Changes
- **CI/CD**: New "Determine build version" step in `docker-publish.yml`, passes `build-args: BUILD_VERSION=...`
- **Dockerfile**: `ARG BUILD_VERSION=dev` + `ENV BUILD_VERSION`
- **Backend**: `config.BUILD_VERSION` read from env, included in `/api/status` response
- **Frontend**: Version link in footer (muted text, turns blue on hover)

## Test plan
- [ ] Local dev: no `BUILD_VERSION` env → footer shows `dev` (clickable)
- [ ] Docker build: `--build-arg BUILD_VERSION=v0.1.2` → footer shows `v0.1.2`
- [ ] Click version text → opens https://github.com/tubalainen/rds-guard in new tab
- [ ] `GET /api/status` response includes `"version"` field

🤖 Generated with [Claude Code](https://claude.com/claude-code)