### PR TITLE
Fix audio playback: stale 206 cache and paginated-out card loss

### DIFF
--- a/static/js/events.js
+++ b/static/js/events.js
@@ -86,6 +86,12 @@ const Events = (() => {
                             list.appendChild(renderEventCard(ev, false));
                         }
                     });
+                    // If the playing card's event is on an older page (outside
+                    // the current LIMIT/offset window), re-append it so the
+                    // audio element is not garbage-collected and playback stops.
+                    if (saved && !saved.card.isConnected) {
+                        list.appendChild(saved.card);
+                    }
                     const shown = list.children.length;
                     loadMore.style.display = shown < total ? 'block' : 'none';
                 }
@@ -119,6 +125,11 @@ const Events = (() => {
                     container.appendChild(renderEventCard(ev, true));
                 }
             });
+            // If the event transitioned out of active state during playback,
+            // re-append the card so the audio element is not garbage-collected.
+            if (saved && !saved.card.isConnected) {
+                container.appendChild(saved.card);
+            }
         } catch (e) {
             // Server not reachable
         }

--- a/web_server.py
+++ b/web_server.py
@@ -169,7 +169,7 @@ async def handle_audio(request):
         headers={
             "Content-Length": str(len(body)),
             "Accept-Ranges": "none",
-            "Cache-Control": "public, max-age=86400",
+            "Cache-Control": "no-store",
         },
     )
 


### PR DESCRIPTION
## Root causes

Two separate bugs were found after the initial Accept-Ranges fix (PR #19).

### 1. Stale browser cache (`web_server.py`)

Chrome cached the **old 206 Partial Content** responses (`Cache-Control: public, max-age=86400`). After PR #19 was deployed, Chrome still served the stale cached partial (~10 s of audio) for previously-played events. It then made a follow-up range request, received a `200 OK` (full file) instead of the expected `206`, and stopped playback.

Fix: `Cache-Control: no-store` so audio files are never cached.

### 2. Playing card lost on poll when event is outside the current page (`events.js`)

The 10-second poll calls `loadEvents(replace=true)`, which resets `offset=0` and fetches only the 50 most recent events. If the playing event is older (e.g. event ID 14 when 50+ events exist), `detachPlayingCard` saves the card but it is never re-inserted because the event is absent from the page response. When `loadEvents` returns, `saved` goes out of scope, the card is garbage-collected, and the audio stops.

The same issue occurs in `loadActiveEvents` when an event transitions from active to completed mid-playback.

Fix: after the `forEach`, check `saved.card.isConnected` and re-append if not yet re-inserted.

## Changes

- `web_server.py`: `Cache-Control: public, max-age=86400` → `Cache-Control: no-store`
- `static/js/events.js`: re-append saved card if `!saved.card.isConnected` in both `loadEvents` and `loadActiveEvents`

## Test plan

- [ ] **Immediate fix**: clear browser cache (or use DevTools → Network → Disable cache), play a previously-broken event — it should play to the end
- [ ] After cache is cleared, play the same event again without clearing cache — still plays to completion (no-store prevents re-caching)
- [ ] With 50+ events, scroll to an old event (outside first page), play it — audio should survive the next 10-second poll
- [ ] Confirm events in the active-events section continue playing when they transition to completed state

🤖 Generated with [Claude Code](https://claude.com/claude-code)