### PR TITLE
feat: multi-station simultaneous monitoring (up to 4 FM stations)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,6 +54,7 @@ COPY config.py /app/config.py
 COPY event_store.py /app/event_store.py
 COPY web_server.py /app/web_server.py
 COPY pipeline.py /app/pipeline.py
+COPY channelizer.py /app/channelizer.py
 COPY rds_guard.py /app/rds_guard.py
 COPY audio_tee.py /app/audio_tee.py
 COPY audio_recorder.py /app/audio_recorder.py

--- a/channelizer.py
+++ b/channelizer.py
@@ -1,0 +1,176 @@
+"""Channelizer — wideband IQ to N×PCM streams for multi-station RDS decoding.
+
+Reads raw unsigned-8-bit IQ samples from rtl_sdr stdout at 2 394 000 S/s,
+extracts each configured station to baseband, and writes 171 kHz signed-16-bit
+mono PCM to one os.pipe() per station.
+
+DSP chain per station (numpy only, no scipy):
+  U8 IQ → complex64 → frequency shift → LPF (127-tap Blackman sinc)
+        → decimate 14 → FM discriminator → s16le → os.pipe()
+
+Key parameters:
+  RTL sample rate: 2 394 000 S/s  (= 171 000 × 14, exact integer ratio)
+  Block size:      16 384 complex samples per RTL IQ chunk (~6.8 ms latency)
+  Decimation:      14  → output 171 000 Hz per station
+  LPF cutoff:      80 kHz  (FM channel half-width is 100 kHz)
+  Filter length:   127 taps (Blackman-windowed sinc)
+"""
+
+import logging
+import os
+import threading
+
+import numpy as np
+
+log = logging.getLogger("rds-guard")
+
+_FS = 2_394_000           # RTL-SDR sample rate
+_OUTPUT_RATE = 171_000    # redsea expected input rate
+_DECIMATION = _FS // _OUTPUT_RATE   # = 14
+_BLOCK = 16_384           # complex samples per IQ block
+_NTAPS = 127              # FIR filter length
+_LPF_CUTOFF = 80_000      # LPF cutoff in Hz
+
+
+def _make_lpf(cutoff_hz: float, fs: float, ntaps: int = _NTAPS) -> np.ndarray:
+    """Blackman-windowed sinc low-pass filter (real, symmetric)."""
+    fc = cutoff_hz / fs
+    n = np.arange(ntaps) - (ntaps - 1) / 2
+    h = np.sinc(2 * fc * n) * np.blackman(ntaps)
+    return (h / h.sum()).astype(np.float32)
+
+
+class _StationDSP:
+    """Per-station DSP state: phase accumulator, filter overlap, FM prev sample."""
+
+    def __init__(self, delta_f: float, fs: float = _FS):
+        # Frequency shift: phasor accumulator
+        self._phase = 0.0
+        self._phase_inc = 2.0 * np.pi * delta_f / fs
+
+        # FIR filter: precompute FFT of zero-padded impulse response
+        lpf = _make_lpf(_LPF_CUTOFF, fs)
+        # FFT size: next power of 2 >= (_BLOCK + _NTAPS - 1)
+        fft_size = 1
+        while fft_size < _BLOCK + _NTAPS - 1:
+            fft_size <<= 1
+        self._fft_size = fft_size
+        h_pad = np.zeros(fft_size, dtype=np.complex64)
+        h_pad[:_NTAPS] = lpf
+        self._H = np.fft.fft(h_pad)   # frequency-domain filter response
+
+        # Overlap buffer (last _NTAPS-1 samples of the previous input block)
+        self._overlap = np.zeros(_NTAPS - 1, dtype=np.complex64)
+
+        # FM discriminator: previous complex sample after decimation
+        self._prev_z = np.complex64(0)
+
+        # Output pipe
+        r, w = os.pipe()
+        self.pipe_r = r
+        self._pipe_w = os.fdopen(w, "wb")
+        self._dead = False
+
+    def process(self, z: np.ndarray) -> None:
+        """Run the full DSP chain on one IQ block and write PCM to the pipe."""
+        n = len(z)
+
+        # 1. Frequency shift to baseband
+        angles = self._phase + self._phase_inc * np.arange(n, dtype=np.float64)
+        phasors = np.exp(1j * angles).astype(np.complex64)
+        zb = z * phasors
+        self._phase = (self._phase + self._phase_inc * n) % (2.0 * np.pi)
+
+        # 2. Overlap-save FFT-based FIR LPF
+        #    Extend with previous overlap, zero-pad to fft_size, multiply spectra
+        extended = np.concatenate([self._overlap, zb])
+        x_pad = np.zeros(self._fft_size, dtype=np.complex64)
+        x_pad[:len(extended)] = extended
+        Y = np.fft.fft(x_pad) * self._H
+        y = np.fft.ifft(Y).astype(np.complex64)
+        #    Valid output for the current block starts at offset _NTAPS-1
+        filtered = y[_NTAPS - 1 : _NTAPS - 1 + n]
+        self._overlap = zb[-(_NTAPS - 1):]
+
+        # 3. Decimate by 14
+        decimated = filtered[::_DECIMATION]
+        if len(decimated) == 0:
+            return
+
+        # 4. FM discriminator: instantaneous phase difference
+        #    angle(z[n] * conj(z[n-1]))
+        z_ext = np.concatenate([[self._prev_z], decimated])
+        product = z_ext[1:] * np.conj(z_ext[:-1])
+        discriminated = np.angle(product).astype(np.float32)
+        self._prev_z = decimated[-1]
+
+        # 5. Scale to s16le and write to output pipe
+        #    FM deviation at 2394 kHz SR ≈ ±0.2 rad for ±75 kHz; scale by 1/π
+        pcm = (discriminated * (32767.0 / np.pi)).clip(-32768, 32767).astype(np.int16)
+        self._write(pcm.tobytes())
+
+    def _write(self, data: bytes) -> None:
+        if self._dead:
+            return
+        try:
+            self._pipe_w.write(data)
+            self._pipe_w.flush()
+        except (BrokenPipeError, OSError):
+            self._dead = True
+            log.warning("Channelizer: pipe closed for a station (redsea exited?)")
+
+    def close(self) -> None:
+        try:
+            self._pipe_w.close()
+        except Exception:
+            pass
+
+
+class Channelizer(threading.Thread):
+    """Daemon thread: reads rtl_sdr IQ, writes 171 kHz PCM to N os.pipe()s.
+
+    Usage::
+
+        ch = Channelizer(rtl_sdr_proc.stdout, [103_500_000, 102_900_000], 103_200_000)
+        ch.start()
+        # ch.pipe_read_fds[i] is the read end of station i's PCM pipe
+    """
+
+    def __init__(self, rtl_sdr_stdout, frequencies_hz: list, center_freq_hz: int):
+        super().__init__(daemon=True, name="channelizer")
+        self._src = rtl_sdr_stdout
+        self._stations = [
+            _StationDSP(freq_hz - center_freq_hz)
+            for freq_hz in frequencies_hz
+        ]
+
+    @property
+    def pipe_read_fds(self) -> list:
+        """Read-end file descriptors (one per station, in config order)."""
+        return [st.pipe_r for st in self._stations]
+
+    def run(self) -> None:
+        log.info("Channelizer started (%d station(s))", len(self._stations))
+        bytes_per_block = _BLOCK * 2   # 2 bytes per sample (I byte + Q byte)
+        try:
+            while True:
+                raw = self._src.read(bytes_per_block)
+                if not raw:
+                    break  # rtl_sdr EOF — process exited
+                if len(raw) < bytes_per_block:
+                    continue  # short read — skip partial block
+
+                # Convert unsigned-8-bit IQ to normalised complex64
+                iq = np.frombuffer(raw, dtype=np.uint8).astype(np.float32)
+                iq = (iq - 127.5) / 127.5
+                z = (iq[0::2] + 1j * iq[1::2]).astype(np.complex64)
+
+                for st in self._stations:
+                    st.process(z)
+
+        except Exception:
+            log.exception("Channelizer: unexpected error in IQ loop")
+        finally:
+            for st in self._stations:
+                st.close()
+            log.info("Channelizer stopped")

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ paho-mqtt>=2.0.0,<3.0.0
 aiohttp>=3.9.0,<4.0.0
 faster-whisper>=1.0.0
 requests>=2.31.0
+numpy>=1.24.0


### PR DESCRIPTION
## Summary

- Adds simultaneous monitoring of up to 4 FM stations from a single RTL-SDR dongle
- Set `FM_FREQUENCIES=103.5M,102.9M` in `.env` to activate (existing `FM_FREQUENCY` single-station path is unchanged)
- New `channelizer.py` performs wideband IQ → N×171 kHz PCM using numpy DSP (no scipy dependency)
- Each station gets its own `redsea`, `AudioRecorder`, and `RulesEngine` instance running in parallel
- `/api/status` returns a `stations[]` array with per-station PI, PS, and decode rate in multi-station mode
- Startup validates: max 4 stations, all frequencies within 2.0 MHz span (aborts with clear error if violated)

## Changed files

| File | Change |
|------|--------|
| `channelizer.py` | **New** — IQ → N×PCM: freq shift + FFT LPF + FM discriminator, one `os.pipe()` per station |
| `config.py` | Parse `FM_FREQUENCIES`, add `MULTI_STATION` flag, startup constraint checks |
| `pipeline.py` | Add `run_pipeline_multi()` for wideband path alongside existing single-station `run_pipeline()` |
| `rds_guard.py` | Per-station `RulesEngine(frequency=...)`, callback factory, `_station_stats`, `_pi_to_freq` |
| `web_server.py` | `GET /api/status` returns `stations[]` in multi-station mode |
| `requirements.txt` | Add `numpy` |
| `Dockerfile` | Copy `channelizer.py` |
| `README.md` | Multi-station monitoring section, updated architecture diagram |

## Test plan

- [ ] **Single-station regression** — leave `.env` with only `FM_FREQUENCY` set; container should behave identically to before
- [ ] **Constraint validation** — set `FM_FREQUENCIES=103.5M,88.0M`; container should log a clear error and exit at startup
- [ ] **Two-station smoke test** — set two nearby P4 frequencies, check `/api/status` returns `stations[]` with both entries and non-zero `groups_per_sec`
- [ ] **Event recording** — trigger TA on one station; verify event card shows correct `frequency` label and audio file is playable
- [ ] **Simultaneous events** — if two stations have active TAs at the same time, verify two independent event rows and audio files

🤖 Generated with [Claude Code](https://claude.com/claude-code)